### PR TITLE
Use rustfmt's defaults.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-indent_style="Block"
-imports_indent="Block"
-use_try_shorthand=true
-use_field_init_shorthand=true
-merge_imports=true


### PR DESCRIPTION
Clinging on to custom settings probably doesn't make sense any more.