### PR TITLE
Upgrade to vob 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0/MIT"
 categories = ["data-structures"]
 
 [dependencies]
-vob = { version="2.0", features=["serde"] }
+vob = { version="3.0", features=["serde"] }
 packedvec = { version="1.0", features=["serde"] }
 serde = { version="1.0", features=["derive"], optional=true }
 num-traits = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ where
 }
 
 fn calc_empties<T: PartialEq>(vec: &[T], empty_val: T) -> Vob {
-    let mut vob = Vob::from_elem(vec.len(), false);
+    let mut vob = Vob::from_elem(false, vec.len());
     for (i, v) in vec.iter().enumerate() {
         if *v == empty_val {
             vob.set(i, true);


### PR DESCRIPTION
I noticed that grmtools projects are currently including both Vob 2.0 and 3.0 because sparsevec hasn't been updated in quite a while.