### PR TITLE
We need to allow the Unicode licence.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,8 +3,6 @@ unlicensed = "deny"
 confidence-threshold = 1.0
 allow = [
     "Apache-2.0",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "ISC",
     "MIT",
+    "Unicode-DFS-2016"
 ]


### PR DESCRIPTION
While I'm here, remove some other licences that cause warnings since we're not using them.