### PR TITLE
Since bincode is unmaintained use wincode instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ license = "Apache-2.0/MIT"
 categories = ["data-structures"]
 
 [features]
-bincode = ["dep:wincode", "vob/bincode", "packedvec/bincode"]
+wincode = ["dep:wincode", "vob/wincode", "packedvec/wincode"]
 serde = ["dep:serde", "vob/serde", "packedvec/serde"]
 
 [dependencies]
-vob = { version="3.0.4" }
-packedvec = { version="1.2.5" }
+vob = { version="4.0" }
+packedvec = { version="2.0" }
 serde = { version="1.0", features=["derive"], optional=true }
 wincode = { version="0.5.5", features=["derive"], optional=true }
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ license = "Apache-2.0/MIT"
 categories = ["data-structures"]
 
 [features]
-bincode = ["dep:bincode", "vob/bincode", "packedvec/bincode"]
+bincode = ["dep:wincode", "vob/bincode", "packedvec/bincode"]
 serde = ["dep:serde", "vob/serde", "packedvec/serde"]
 
 [dependencies]
 vob = { version="3.0.4" }
 packedvec = { version="1.2.5" }
 serde = { version="1.0", features=["derive"], optional=true }
-bincode = { version="2.0", features=["derive"], optional=true }
+wincode = { version="0.5.5", features=["derive"], optional=true }
 num-traits = "0.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::many_single_char_names)]
 
-#[cfg(feature = "bincode")]
-use wincode::{SchemaRead, SchemaWrite};
 use num_traits::{AsPrimitive, FromPrimitive, PrimInt, ToPrimitive, Unsigned};
 use packedvec::PackedVec;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use vob::Vob;
+#[cfg(feature = "wincode")]
+use wincode::{SchemaRead, SchemaWrite};
 
 /// A SparseVec efficiently encodes a two-dimensional matrix of integers. The input matrix must be
 /// encoded as a one-dimensional vector of integers with a row-length. Given an "empty" value, the
@@ -62,7 +62,7 @@ use vob::Vob;
 /// value = c[pos] // =3
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "bincode", derive(SchemaRead, SchemaWrite))]
+#[cfg_attr(feature = "wincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug)]
 pub struct SparseVec<T> {
     displacement: Vec<usize>, // Displacement vector

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::many_single_char_names)]
 
 #[cfg(feature = "bincode")]
-use bincode::{Decode, Encode};
+use wincode::{SchemaRead, SchemaWrite};
 use num_traits::{AsPrimitive, FromPrimitive, PrimInt, ToPrimitive, Unsigned};
 use packedvec::PackedVec;
 #[cfg(feature = "serde")]
@@ -62,7 +62,7 @@ use vob::Vob;
 /// value = c[pos] // =3
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "bincode", derive(Encode, Decode))]
+#[cfg_attr(feature = "bincode", derive(SchemaRead, SchemaWrite))]
 #[derive(Debug)]
 pub struct SparseVec<T> {
     displacement: Vec<usize>, // Displacement vector


### PR DESCRIPTION
This is part of a series of patches to various crates moving from the bincode crate to the wincode crate.
I believe the reverse order of dependencies is:

1. packedvec
2. sparsevec
3. vob
4. grmtools

I'm currently leaving how we want to deal with semver up in the air. Since these do change trait impls around,
It may be that as we release these we need to fiddle with the version numbers in `Cargo.toml` too.