### PR TITLE
Remove travis-ci badges from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://api.travis-ci.org/softdevteam/sparsevec.svg?branch=master)](https://travis-ci.org/softdevteam/sparsevec)
 [![Latest version](https://img.shields.io/crates/v/sparsevec.svg)](https://crates.io/crates/sparsevec)
 [![Documentation](https://docs.rs/sparsevec/badge.svg)](https://docs.rs/sparsevec)
 


### PR DESCRIPTION
Following https://github.com/softdevteam/grmtools/pull/653 It occurred to me I should check some more repos.

The travis-ci badge wasn't rendering, and clicking the it showed a progress indicator that seemed to spin indefinitely.
I'm assuming that like vob these repositories no longer reply on travis.